### PR TITLE
Add ShopCubit and Register in Service Locator

### DIFF
--- a/lib/core/utils/service_locator/service_locator.dart
+++ b/lib/core/utils/service_locator/service_locator.dart
@@ -7,6 +7,7 @@ import 'package:t_store/features/shop/domain/usecases/get_products_by_category_u
 import 'package:t_store/features/shop/domain/usecases/get_products_by_search_usecase.dart';
 import 'package:t_store/features/shop/domain/usecases/get_products_list_usecase.dart';
 import 'package:t_store/features/shop/domain/usecases/get_sorted_products_usecase.dart';
+import 'package:t_store/features/shop/presentation/controller/shop_cubit.dart';
 
 final getIt = GetIt.instance;
 
@@ -35,4 +36,13 @@ setupServiceLocator() {
       GetProductByIdUsecase(shopRepository: getIt.get<ShopRepositoryImpl>()));
   getIt.registerSingleton<GetSortedProductsUsecase>(GetSortedProductsUsecase(
       shopRepository: getIt.get<ShopRepositoryImpl>()));
+
+// register controllers
+  getIt.registerSingleton<ShopCubit>(ShopCubit(
+    getProductsListUsecase: getIt.get<GetProductsListUsecase>(),
+    getProductsBySearchUsecase: getIt.get<GetProductsBySearchUsecase>(),
+    getProductsByCategoryUsecase: getIt.get<GetProductsByCategoryUsecase>(),
+    getProductByIdUsecase: getIt.get<GetProductByIdUsecase>(),
+    getSortedProductsUsecase: getIt.get<GetSortedProductsUsecase>(),
+  ));
 }

--- a/lib/features/shop/presentation/controller/shop_cubit.dart
+++ b/lib/features/shop/presentation/controller/shop_cubit.dart
@@ -1,0 +1,67 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:t_store/core/utils/exceptions/exceptions.dart';
+import 'package:t_store/features/shop/domain/entities/product_entity.dart';
+import 'package:t_store/features/shop/domain/usecases/get_product_by_id_usecase.dart';
+import 'package:t_store/features/shop/domain/usecases/get_products_by_category_usecase.dart';
+import 'package:t_store/features/shop/domain/usecases/get_products_by_search_usecase.dart';
+import 'package:t_store/features/shop/domain/usecases/get_products_list_usecase.dart';
+import 'package:t_store/features/shop/domain/usecases/get_sorted_products_usecase.dart';
+
+part 'shop_state.dart';
+
+class ShopCubit extends Cubit<ShopState> {
+  ShopCubit(
+    {
+      required this.getProductsListUsecase,
+      required this.getSortedProductsUsecase,
+      required this.getProductByIdUsecase,
+      required this.getProductsByCategoryUsecase,
+      required this.getProductsBySearchUsecase
+    })
+      : super(ShopInitial());
+  final GetProductsListUsecase getProductsListUsecase;
+  final GetSortedProductsUsecase getSortedProductsUsecase;
+  final GetProductByIdUsecase getProductByIdUsecase;
+  final GetProductsByCategoryUsecase getProductsByCategoryUsecase;
+  final GetProductsBySearchUsecase getProductsBySearchUsecase;
+
+  void getProductsList() async {
+    emit(ShopLoading());
+
+    final products = await getProductsListUsecase.call();
+    products.fold((error) => emit(ShopError(error: error)),
+        (productsList) => emit(ShopProductsLoaded(productsList: productsList)));
+  }
+
+  void getSortedProducts(
+      {required String sortBy, required String sortType}) async {
+    emit(ShopLoading());
+    final products =
+        await getSortedProductsUsecase.call(sortBy: sortBy, sortType: sortType);
+    products.fold((error) => emit(ShopError(error: error)),
+        (productsList) => emit(ShopProductsLoaded(productsList: productsList)));
+  }
+
+  void getProductById({required int productId}) async {
+    emit(ShopLoading());
+    final product = await getProductByIdUsecase.call(productId: productId);
+    product.fold((error) => emit(ShopError(error: error)),
+        (product) => emit(ShopProductLoaded(product: product)));
+  }
+
+  void getProductsByCategory({required String categoryName}) async {
+    emit(ShopLoading());
+    final products =
+        await getProductsByCategoryUsecase.call(categoryName: categoryName);
+    products.fold((error) => emit(ShopError(error: error)),
+        (productsList) => emit(ShopProductsLoaded(productsList: productsList)));
+  }
+
+  void getProductsBySearch({String? search}) async {
+    emit(ShopLoading());
+    final products = await getProductsBySearchUsecase.call(search: search);
+    products.fold((error) => emit(ShopError(error: error)),
+        (productsList) => emit(ShopProductsLoaded(productsList: productsList)));
+  }
+}

--- a/lib/features/shop/presentation/controller/shop_state.dart
+++ b/lib/features/shop/presentation/controller/shop_state.dart
@@ -1,0 +1,33 @@
+part of 'shop_cubit.dart';
+
+abstract class ShopState extends Equatable {
+  const ShopState();
+
+  @override
+  List<Object> get props => [];
+}
+
+class ShopInitial extends ShopState {}
+
+class ShopLoading extends ShopState {}
+
+class ShopProductsLoaded extends ShopState {
+  final List<ProductEntity> productsList;
+  const ShopProductsLoaded({required this.productsList});
+
+  @override
+  List<Object> get props => [productsList];
+}
+
+class ShopProductLoaded extends ShopState {
+  final ProductEntity product;
+  const ShopProductLoaded({required this.product});
+
+  @override
+  List<Object> get props => [product];
+}
+
+class ShopError extends ShopState {
+  final TExceptions error;
+  const ShopError({required this.error});
+}


### PR DESCRIPTION
### Description
This PR introduces the `ShopCubit` for managing product-related state and interactions in the shop feature. The cubit handles fetching all products, fetching sorted products, fetching product by ID, fetching products by category, and fetching products by search. It also registers the cubit in the service locator for dependency injection.

### Changes
- Added `ShopCubit` with the following functionalities:
  - Fetch all products.
  - Fetch sorted products.
  - Fetch product by ID.
  - Fetch products by category.
  - Fetch products by search.
- Registered `ShopCubit` in the service locator.

### Additional Information
These changes enable efficient state management and interaction handling for the shop feature, ensuring a smooth and responsive user experience.
