### PR TITLE
Refactor: Separate Main and App Logic into Individual Files

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,31 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:t_store/core/utils/constants/text_strings.dart';
 import 'package:t_store/core/utils/service_locator/service_locator.dart';
-import 'package:t_store/core/utils/theme/theme.dart';
-import 'package:t_store/features/auth/presentation/cubit/on_boarding_cubit.dart';
-import 'package:t_store/features/auth/presentation/views/on_boarding/on_boarding_view.dart';
+import 'package:t_store/t_store.dart';
 
 void main() async {
   await setupServiceLocator();
 
-  runApp(const MyApp());
-}
-
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: TTexts.appName,
-      themeMode: ThemeMode.system,
-      theme: TAppTheme.lightTheme,
-      darkTheme: TAppTheme.darkTheme,
-      debugShowCheckedModeBanner: false,
-      home: BlocProvider(
-        create: (context) => OnBoardingCubit(),
-        child: const OnBoardingView(),
-      ),
-    );
-  }
+  runApp(const TStore());
 }

--- a/lib/t_store.dart
+++ b/lib/t_store.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:t_store/core/utils/constants/text_strings.dart';
+import 'package:t_store/core/utils/theme/theme.dart';
+import 'package:t_store/features/auth/presentation/cubit/on_boarding_cubit.dart';
+import 'package:t_store/features/auth/presentation/views/on_boarding/on_boarding_view.dart';
+
+class TStore extends StatelessWidget {
+  const TStore({super.key});
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: TTexts.appName,
+      themeMode: ThemeMode.system,
+      theme: TAppTheme.lightTheme,
+      darkTheme: TAppTheme.darkTheme,
+      debugShowCheckedModeBanner: false,
+      home: BlocProvider(
+        create: (context) => OnBoardingCubit(),
+        child: const OnBoardingView(),
+      ),
+    );
+  }
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -7,13 +7,12 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'package:t_store/main.dart';
+import 'package:t_store/t_store.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const TStore());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
- Separated the main initialization logic and app structure into two different files.
- `main.dart` now handles setup and initialization.
- `t_store.dart` contains the main app widget configuration.
- This refactor improves the organization and makes it easier to manage flavors and other operations in the future.
